### PR TITLE
Rename reflector -> reflect

### DIFF
--- a/message-format.md
+++ b/message-format.md
@@ -113,7 +113,7 @@ msg = {
     "request-full": any((True, ["NODE_ID"])),
 
     # requesting reflection, OPTIONAL
-    "reflector": {
+    "reflect": {
         "seq": 666  # Example of a reflection request
     },
 
@@ -208,7 +208,7 @@ msg = {
     "request-full": any((True, ["NODE_ID", ...])),
 
     # requesting reflection, OPTIONAL
-    "reflector": {
+    "reflect": {
         "seq": 666  # Example of a reflection request
     },
 


### PR DESCRIPTION
Reflector is a substantive and is the one who reflects something

reflect can be understood as the imperative, or as "please reflect this"

This is imho a better name for it and is more on the point of the
meaning of this field